### PR TITLE
invert the condition check for apps.get_model

### DIFF
--- a/src/django_wools/db.py
+++ b/src/django_wools/db.py
@@ -37,7 +37,7 @@ def require_lock(model: Union[Text, Model], lock: Text):
                 raise ValueError("%s is not a PostgreSQL supported lock mode.")
             from django.db import connection
 
-            if not isinstance(model, Model):
+            if type(model) is Text:
                 true_model = apps.get_model(model)
             else:
                 true_model = model


### PR DESCRIPTION
My custom User classes (descendants of AbstractBaseUser) don't pass the isinstance check.
This PR inverts the condition, since apps.get_model uses it's first argument as string.